### PR TITLE
Trihung

### DIFF
--- a/src/main/java/com/vinaacademy/platform/feature/cart/CartController.java
+++ b/src/main/java/com/vinaacademy/platform/feature/cart/CartController.java
@@ -33,25 +33,25 @@ public class CartController {
     @Autowired
 	private CartItemService cartItemService;
 	
-	@HasAnyRole({AuthConstants.STUDENT_ROLE}) 
-    @PostMapping
-    @Operation(summary = "Tạo giỏ hàng mới", description = "Tạo giỏ hàng mới cho học viên")
-    public ResponseEntity<ApiResponse<CartDto>> createCart(@RequestBody @Valid CartRequest request) {
-        log.debug("Cart created");
-        CartDto cart = cartService.createCart(request);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.<CartDto>builder()
-                        .status("success")
-                        .message("Tạo giỏ hàng thành công")
-                        .data(cart)
-                        .build());    }
+//	@HasAnyRole({AuthConstants.STUDENT_ROLE}) 
+//    @PostMapping
+//    @Operation(summary = "Tạo giỏ hàng mới", description = "Tạo giỏ hàng mới cho học viên")
+//    public ResponseEntity<ApiResponse<CartDto>> createCart(@RequestBody @Valid CartRequest request) {
+//        log.debug("Cart created");
+//        CartDto cart = cartService.createCart(request);
+//        return ResponseEntity.status(HttpStatus.CREATED)
+//                .body(ApiResponse.<CartDto>builder()
+//                        .status("success")
+//                        .message("Tạo giỏ hàng thành công")
+//                        .data(cart)
+//                        .build());    }
 
     @HasAnyRole({AuthConstants.STUDENT_ROLE})
-    @GetMapping("/{userId}")
+    @GetMapping
     @Operation(summary = "Lấy thông tin giỏ hàng", description = "Lấy thông tin giỏ hàng của học viên")
-    public ResponseEntity<ApiResponse<CartDto>> getCart(@PathVariable UUID userId) {
-        log.debug("Get cart for user " + userId);
-        CartDto cart = cartService.getCart(userId);
+    public ResponseEntity<ApiResponse<CartDto>> getCart() {
+        log.debug("Get cart");
+        CartDto cart = cartService.getCart();
         return ResponseEntity.ok(ApiResponse.<CartDto>builder()
                 .status("success")
                 .data(cart)
@@ -73,11 +73,11 @@ public class CartController {
     }
 
     @HasAnyRole({AuthConstants.STUDENT_ROLE})
-    @GetMapping("/{userId}/items")
+    @GetMapping("/items")
     @Operation(summary = "Lấy danh sách sản phẩm", description = "Lấy danh sách các khóa học trong giỏ hàng")
-    public ResponseEntity<ApiResponse<List<CartItemDto>>> getListCartItems(@PathVariable UUID userId) {
-        log.debug("Get list cart items for user " + userId);
-        List<CartItemDto> cartItems = cartService.getCart(userId).getCartItems();
+    public ResponseEntity<ApiResponse<List<CartItemDto>>> getListCartItems() {
+        log.debug("Get list cart items for user");
+        List<CartItemDto> cartItems = cartService.getCart().getCartItems();
         return ResponseEntity.ok(ApiResponse.<List<CartItemDto>>builder()
                 .status("success")
                 .data(cartItems)

--- a/src/main/java/com/vinaacademy/platform/feature/cart/CartController.java
+++ b/src/main/java/com/vinaacademy/platform/feature/cart/CartController.java
@@ -33,25 +33,25 @@ public class CartController {
     @Autowired
 	private CartItemService cartItemService;
 	
-//	@HasAnyRole({AuthConstants.STUDENT_ROLE}) 
-//    @PostMapping
-//    @Operation(summary = "Tạo giỏ hàng mới", description = "Tạo giỏ hàng mới cho học viên")
-//    public ResponseEntity<ApiResponse<CartDto>> createCart(@RequestBody @Valid CartRequest request) {
-//        log.debug("Cart created");
-//        CartDto cart = cartService.createCart(request);
-//        return ResponseEntity.status(HttpStatus.CREATED)
-//                .body(ApiResponse.<CartDto>builder()
-//                        .status("success")
-//                        .message("Tạo giỏ hàng thành công")
-//                        .data(cart)
-//                        .build());    }
+	@HasAnyRole({AuthConstants.STUDENT_ROLE}) 
+    @PostMapping
+    @Operation(summary = "Tạo giỏ hàng mới", description = "Tạo giỏ hàng mới cho học viên")
+    public ResponseEntity<ApiResponse<CartDto>> createCart(@RequestBody @Valid CartRequest request) {
+        log.debug("Cart created");
+        CartDto cart = cartService.createCart(request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.<CartDto>builder()
+                        .status("success")
+                        .message("Tạo giỏ hàng thành công")
+                        .data(cart)
+                        .build());    }
 
     @HasAnyRole({AuthConstants.STUDENT_ROLE})
-    @GetMapping
+    @GetMapping("/{userId}")
     @Operation(summary = "Lấy thông tin giỏ hàng", description = "Lấy thông tin giỏ hàng của học viên")
-    public ResponseEntity<ApiResponse<CartDto>> getCart() {
-        log.debug("Get cart");
-        CartDto cart = cartService.getCart();
+    public ResponseEntity<ApiResponse<CartDto>> getCart(@PathVariable UUID userId) {
+        log.debug("Get cart for user " + userId);
+        CartDto cart = cartService.getCart(userId);
         return ResponseEntity.ok(ApiResponse.<CartDto>builder()
                 .status("success")
                 .data(cart)
@@ -73,11 +73,11 @@ public class CartController {
     }
 
     @HasAnyRole({AuthConstants.STUDENT_ROLE})
-    @GetMapping("/items")
+    @GetMapping("/{userId}/items")
     @Operation(summary = "Lấy danh sách sản phẩm", description = "Lấy danh sách các khóa học trong giỏ hàng")
-    public ResponseEntity<ApiResponse<List<CartItemDto>>> getListCartItems() {
-        log.debug("Get list cart items for user");
-        List<CartItemDto> cartItems = cartService.getCart().getCartItems();
+    public ResponseEntity<ApiResponse<List<CartItemDto>>> getListCartItems(@PathVariable UUID userId) {
+        log.debug("Get list cart items for user " + userId);
+        List<CartItemDto> cartItems = cartService.getCart(userId).getCartItems();
         return ResponseEntity.ok(ApiResponse.<List<CartItemDto>>builder()
                 .status("success")
                 .data(cartItems)

--- a/src/main/java/com/vinaacademy/platform/feature/cart/service/CartItemService.java
+++ b/src/main/java/com/vinaacademy/platform/feature/cart/service/CartItemService.java
@@ -17,7 +17,7 @@ public interface CartItemService {
 	 
 	 List<CartItemDto> getCartItems(Long cartId);
 	 
-	 List<CartItem> getCartItems();
+	 List<CartItem> getCartItems(UUID userId);
 	 
 	 CartItemDto getCartItem(Long cartItemId);
 }

--- a/src/main/java/com/vinaacademy/platform/feature/cart/service/CartItemService.java
+++ b/src/main/java/com/vinaacademy/platform/feature/cart/service/CartItemService.java
@@ -17,7 +17,7 @@ public interface CartItemService {
 	 
 	 List<CartItemDto> getCartItems(Long cartId);
 	 
-	 List<CartItem> getCartItems(UUID userId);
+	 List<CartItem> getCartItems();
 	 
 	 CartItemDto getCartItem(Long cartItemId);
 }

--- a/src/main/java/com/vinaacademy/platform/feature/cart/service/CartItemServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/cart/service/CartItemServiceImpl.java
@@ -10,9 +10,6 @@ import com.vinaacademy.platform.feature.cart.repository.CartItemRepository;
 import com.vinaacademy.platform.feature.cart.repository.CartRepository;
 import com.vinaacademy.platform.feature.course.entity.Course;
 import com.vinaacademy.platform.feature.course.repository.CourseRepository;
-import com.vinaacademy.platform.feature.user.auth.helpers.SecurityHelper;
-import com.vinaacademy.platform.feature.user.entity.User;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -30,8 +27,6 @@ public class CartItemServiceImpl implements CartItemService{
 	private CartMapper cartMapper;
 	@Autowired
 	private CourseRepository courseRepository;
-	@Autowired
-    private SecurityHelper securityHelper;
 	
 	@Override
 	public CartItemDto addCartItem(CartItemRequest request) {
@@ -39,13 +34,6 @@ public class CartItemServiceImpl implements CartItemService{
 				() -> BadRequestException.message("Không tìm thấy Cart ID này"));
 		Course course = courseRepository.findById(request.getCourse_id()).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy Course ID này"));
-		
-		User user = securityHelper.getCurrentUser();
-    	UUID userId = user.getId();
-    	
-		if (cart.getUser().getId() != userId ) {
-    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
-    	}
 		
 		if (cartItemRepository.existsByCourseIdAndCart(course.getId(), cart))
 			throw BadRequestException.message("Duplicate course: Course id này đã tồn tại trong giỏ hàng");
@@ -73,12 +61,6 @@ public class CartItemServiceImpl implements CartItemService{
 		CartItem cartItem = cartItemRepository.findById(request.getId()).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy Cart Item này"));
 		
-		User user = securityHelper.getCurrentUser();
-    	UUID userId = user.getId();
-    	
-		if (cart.getUser().getId() != userId ) {
-    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
-    	}
 		
 		cartItem.setCourse(course);
 		cartItem.setCart(cart);
@@ -94,14 +76,6 @@ public class CartItemServiceImpl implements CartItemService{
 	public void deleteCartItem(Long cartItemId) {
 		CartItem cartItem = cartItemRepository.findById(cartItemId).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy Cart Item này"));
-		Cart cart = cartItem.getCart();
-		User user = securityHelper.getCurrentUser();
-    	UUID userId = user.getId();
-    	
-		if (cart.getUser().getId() != userId ) {
-    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
-    	}
-		
 		cartItemRepository.delete(cartItem);
 	}
 
@@ -109,12 +83,6 @@ public class CartItemServiceImpl implements CartItemService{
 	public List<CartItemDto> getCartItems(Long cartId) {
 		Cart cart = cartRepository.findById(cartId).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy Cart ID này"));
-		User user = securityHelper.getCurrentUser();
-    	UUID userId = user.getId();
-    	
-		if (cart.getUser().getId() != userId ) {
-    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
-    	}
 		List<CartItemDto> cartItemDtos = cartMapper.toCartItemDTOList(cart.getCartItems());
 		return cartItemDtos;
 	}
@@ -123,25 +91,14 @@ public class CartItemServiceImpl implements CartItemService{
 	public CartItemDto getCartItem(Long cartItemId) {
 		CartItem cartItem = cartItemRepository.findById(cartItemId).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy ID Cart Item này"));
-		Cart cart = cartItem.getCart();
-		User user = securityHelper.getCurrentUser();
-    	UUID userId = user.getId();
-    	
-		if (cart.getUser().getId() != userId ) {
-    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
-    	}
 		CartItemDto cartItemDto = cartMapper.toCartItemDTO(cartItem);
 		return cartItemDto;
 	}
 
 	@Override
-	public List<CartItem> getCartItems() {
-		User user = securityHelper.getCurrentUser();
-    	UUID userId = user.getId();
-
+	public List<CartItem> getCartItems(UUID userId) {
 		Cart cart = cartRepository.findByUserId(userId).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy Cart của User ID này"));
-		
 		return cart.getCartItems();
 	}
 

--- a/src/main/java/com/vinaacademy/platform/feature/cart/service/CartItemServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/cart/service/CartItemServiceImpl.java
@@ -10,6 +10,9 @@ import com.vinaacademy.platform.feature.cart.repository.CartItemRepository;
 import com.vinaacademy.platform.feature.cart.repository.CartRepository;
 import com.vinaacademy.platform.feature.course.entity.Course;
 import com.vinaacademy.platform.feature.course.repository.CourseRepository;
+import com.vinaacademy.platform.feature.user.auth.helpers.SecurityHelper;
+import com.vinaacademy.platform.feature.user.entity.User;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +30,8 @@ public class CartItemServiceImpl implements CartItemService{
 	private CartMapper cartMapper;
 	@Autowired
 	private CourseRepository courseRepository;
+	@Autowired
+    private SecurityHelper securityHelper;
 	
 	@Override
 	public CartItemDto addCartItem(CartItemRequest request) {
@@ -34,6 +39,13 @@ public class CartItemServiceImpl implements CartItemService{
 				() -> BadRequestException.message("Không tìm thấy Cart ID này"));
 		Course course = courseRepository.findById(request.getCourse_id()).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy Course ID này"));
+		
+		User user = securityHelper.getCurrentUser();
+    	UUID userId = user.getId();
+    	
+		if (cart.getUser().getId() != userId ) {
+    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
+    	}
 		
 		if (cartItemRepository.existsByCourseIdAndCart(course.getId(), cart))
 			throw BadRequestException.message("Duplicate course: Course id này đã tồn tại trong giỏ hàng");
@@ -61,6 +73,12 @@ public class CartItemServiceImpl implements CartItemService{
 		CartItem cartItem = cartItemRepository.findById(request.getId()).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy Cart Item này"));
 		
+		User user = securityHelper.getCurrentUser();
+    	UUID userId = user.getId();
+    	
+		if (cart.getUser().getId() != userId ) {
+    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
+    	}
 		
 		cartItem.setCourse(course);
 		cartItem.setCart(cart);
@@ -76,6 +94,14 @@ public class CartItemServiceImpl implements CartItemService{
 	public void deleteCartItem(Long cartItemId) {
 		CartItem cartItem = cartItemRepository.findById(cartItemId).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy Cart Item này"));
+		Cart cart = cartItem.getCart();
+		User user = securityHelper.getCurrentUser();
+    	UUID userId = user.getId();
+    	
+		if (cart.getUser().getId() != userId ) {
+    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
+    	}
+		
 		cartItemRepository.delete(cartItem);
 	}
 
@@ -83,6 +109,12 @@ public class CartItemServiceImpl implements CartItemService{
 	public List<CartItemDto> getCartItems(Long cartId) {
 		Cart cart = cartRepository.findById(cartId).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy Cart ID này"));
+		User user = securityHelper.getCurrentUser();
+    	UUID userId = user.getId();
+    	
+		if (cart.getUser().getId() != userId ) {
+    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
+    	}
 		List<CartItemDto> cartItemDtos = cartMapper.toCartItemDTOList(cart.getCartItems());
 		return cartItemDtos;
 	}
@@ -91,14 +123,25 @@ public class CartItemServiceImpl implements CartItemService{
 	public CartItemDto getCartItem(Long cartItemId) {
 		CartItem cartItem = cartItemRepository.findById(cartItemId).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy ID Cart Item này"));
+		Cart cart = cartItem.getCart();
+		User user = securityHelper.getCurrentUser();
+    	UUID userId = user.getId();
+    	
+		if (cart.getUser().getId() != userId ) {
+    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
+    	}
 		CartItemDto cartItemDto = cartMapper.toCartItemDTO(cartItem);
 		return cartItemDto;
 	}
 
 	@Override
-	public List<CartItem> getCartItems(UUID userId) {
+	public List<CartItem> getCartItems() {
+		User user = securityHelper.getCurrentUser();
+    	UUID userId = user.getId();
+
 		Cart cart = cartRepository.findByUserId(userId).orElseThrow(
 				() -> BadRequestException.message("Không tìm thấy Cart của User ID này"));
+		
 		return cart.getCartItems();
 	}
 

--- a/src/main/java/com/vinaacademy/platform/feature/cart/service/CartService.java
+++ b/src/main/java/com/vinaacademy/platform/feature/cart/service/CartService.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 public interface CartService {
 	
-	 CartDto getCart(UUID userId);
+	 CartDto getCart();
 	 
 	 CartDto createCart(CartRequest request);
 

--- a/src/main/java/com/vinaacademy/platform/feature/cart/service/CartService.java
+++ b/src/main/java/com/vinaacademy/platform/feature/cart/service/CartService.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 public interface CartService {
 	
-	 CartDto getCart();
+	 CartDto getCart(UUID userId);
 	 
 	 CartDto createCart(CartRequest request);
 

--- a/src/main/java/com/vinaacademy/platform/feature/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/cart/service/CartServiceImpl.java
@@ -9,7 +9,6 @@ import com.vinaacademy.platform.feature.cart.repository.CartRepository;
 import com.vinaacademy.platform.feature.order_payment.entity.Coupon;
 import com.vinaacademy.platform.feature.order_payment.repository.CouponRepository;
 import com.vinaacademy.platform.feature.user.UserRepository;
-import com.vinaacademy.platform.feature.user.auth.helpers.SecurityHelper;
 import com.vinaacademy.platform.feature.user.entity.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -26,13 +25,9 @@ public class CartServiceImpl implements CartService {
     private CartMapper cartMapper;
     @Autowired
     private CouponRepository couponRepository;
-    @Autowired
-    private SecurityHelper securityHelper;
 
     @Override
-    public CartDto getCart() {
-    	User user = securityHelper.getCurrentUser();
-    	UUID userId = user.getId();
+    public CartDto getCart(UUID userId) {
         Cart cart = cartRepository.findByUserId(userId)
                 .orElse(null);
         CartDto cartDto = cartMapper.toDTO(cart);
@@ -63,21 +58,15 @@ public class CartServiceImpl implements CartService {
     public CartDto updateCart(CartRequest request) {
         Cart cart = cartRepository.findByUserId(request.getUser_id())
                 .orElseThrow(() -> BadRequestException.message("Không tìm thấy Cart của ID người dùng này"));
-        User user = securityHelper.getCurrentUser();
-    	UUID userId = user.getId();
-    	
-    	if (request.getUser_id() != userId) {
-    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
-    	}
-    	
+        User userp = userRepository.findById(request.getUser_id())
+                .orElseThrow(() -> BadRequestException.message("Không tìm thấy ID người dùng này"));
         Coupon coupon = null;
         if (request.getCoupon_id() != null) {
             coupon = couponRepository.findById(request.getCoupon_id())
                     .orElseThrow(() -> BadRequestException.message("Không tìm thấy coupon"));
         }
-        
         cart.setCoupon(coupon);
-        cart.setUser(user);
+        cart.setUser(userp);
         cartRepository.save(cart);
         CartDto cartDto = cartMapper.toDTO(cart);
         return cartDto;
@@ -87,13 +76,6 @@ public class CartServiceImpl implements CartService {
     public void deleteCart(CartRequest request) {
         Cart cart = cartRepository.findByUserId(request.getUser_id())
                 .orElseThrow(() -> BadRequestException.message("Không tìm thấy Cart của ID người dùng này"));
-        
-        User user = securityHelper.getCurrentUser();
-    	UUID userId = user.getId();
-    	if (request.getUser_id() != userId) {
-    		throw BadRequestException.message("Bạn không có quyền sở hữu với cart này");
-    	}
-    	
         cartRepository.delete(cart);
     }
 

--- a/src/main/java/com/vinaacademy/platform/feature/order_payment/service/OrderServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/order_payment/service/OrderServiceImpl.java
@@ -96,7 +96,7 @@ public class OrderServiceImpl implements OrderService {
 		order.calculateAmounts();
 		order = orderRepository.save(order);
 
-//		//xoa all item trong cart
+//		xoa all item trong cart
 		
 		for (CartItem cartitem: cartItems) {
 			log.debug("Xóa "+cartitem.getId());

--- a/src/main/java/com/vinaacademy/platform/feature/order_payment/service/OrderServiceImpl.java
+++ b/src/main/java/com/vinaacademy/platform/feature/order_payment/service/OrderServiceImpl.java
@@ -96,7 +96,7 @@ public class OrderServiceImpl implements OrderService {
 		order.calculateAmounts();
 		order = orderRepository.save(order);
 
-//		xoa all item trong cart
+//		//xoa all item trong cart
 		
 		for (CartItem cartitem: cartItems) {
 			log.debug("Xóa "+cartitem.getId());


### PR DESCRIPTION
valiadate for cart (owner only)

## Summary by Sourcery

Enforce cart ownership validation by verifying current user is the cart owner for all cart and cart item operations and refactor endpoints to use the authenticated user instead of explicit userId parameters.

Enhancements:
- Inject SecurityHelper and add ownership checks in CartItemServiceImpl to restrict add, update, delete, and retrieval of cart items to the cart owner
- Inject SecurityHelper and add ownership checks in CartServiceImpl to restrict cart retrieval, update, and deletion to the cart owner
- Refactor CartController to remove userId path parameters from getCart and getListCartItems endpoints and derive the user context from the authenticated user
- Update CartService and CartItemService interfaces and method signatures to drop userId parameters and fetch the current user from SecurityHelper
- Comment out the createCart endpoint in CartController (temporarily disabled)