### PR TITLE
feat(config): add configuration files for code review tools and security rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,80 @@
+# .coderabbit.yaml
+language: vi-VN
+
+tone_instructions: "Vui lòng nói thẳng vấn đề và thẳng thắn"
+
+reviews:
+  profile: assertive
+  high_level_summary: false
+  collapse_walkthrough: true
+  changed_files_summary: false
+  sequence_diagrams: true         # tự vẽ sequence diagram trong Walkthrough
+  suggested_labels: false
+  suggested_reviewers: false
+  related_issues: false
+  related_prs: false
+  assess_linked_issues: false
+  estimate_code_review_effort: false
+  poem: false
+
+  # Chỉ rõ phạm vi & cách review cho thư mục src/**
+  path_instructions:
+    - path: "src/**"
+      instructions: |
+        Chỉ review file trong thư mục src/**.
+        Mục tiêu duy nhất: phát hiện và mô tả CÁC LỖ HỔNG NGHIÊM TRỌNG (security/bug risk) như mô tả trong tone_instructions.
+        KHÔNG:
+          - không gợi ý refactor/clean code/perf vi mô/style.
+          - không nhận xét naming/comment/format.
+        CẦN:
+          - vẽ sequence diagram mô tả data flow/attack path nếu có.
+          - chỉ ra vị trí mã nguồn, điều kiện kích hoạt, tác động.
+          - đề xuất biện pháp giảm thiểu ở mức bảo mật/cấu hình (ngắn gọn), tránh refactor code không cần thiết.
+
+  path_filters:
+    - "src/**"
+    - "!**/test/**"
+    - "!**/*.md"
+    - "!docs/**"
+
+  auto_review:
+    enabled: true
+    drafts: false
+    ignore_title_keywords:
+      - "chore"
+      - "docs"
+      - "refactor"
+
+  tools:
+    # ---- Security / secrets / infra ----
+    gitleaks:
+      enabled: true
+    hadolint:
+      enabled: true
+    yamllint:
+      enabled: true
+    checkov:
+      enabled: false               # bật nếu repo có Terraform/K8s
+
+    # ---- Java bug risk (bật) ----
+    pmd:
+      enabled: true
+      # Dùng ruleset chỉ bắt lỗi rủi ro cao
+      config_file: ".pmd-ruleset.xml"
+
+    semgrep:
+      enabled: true
+      # Dùng rule local chỉ nhắm lỗ hổng nghiêm trọng
+      config_file: ".semgrep.yml"
+
+    # ---- Tắt các linter không liên quan để tránh nhiễu ----
+    eslint: { enabled: false }
+    ruff: { enabled: false }
+    golangci-lint: { enabled: false }
+    markdownlint: { enabled: false }
+    languagetool: { enabled: false }
+    phpcs: { enabled: false }
+    phpmd: { enabled: false }
+    phpstan: { enabled: false }
+    swiftlint: { enabled: false }
+    oxc: { enabled: false }

--- a/.pmd-ruleset.xml
+++ b/.pmd-ruleset.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset
+  name="BugRiskOnly"
+  xmlns="https://pmd.github.io/pmd-7.0.0/ruleset/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://pmd.github.io/pmd-7.0.0/ruleset/2.0.0 https://pmd.github.io/pmd-7.0.0/ruleset_2_0_0.xsd">
+  <description>Only correctness/security/concurrency/resource-leak/perf risks</description>
+
+  <!-- Correctness / robustness -->
+  <rule ref="category/java/errorprone.xml/NullAssignment"/>
+  <rule ref="category/java/errorprone.xml/AvoidCatchingGenericException"/>
+  <rule ref="category/java/errorprone.xml/CloseResource"/>
+  <rule ref="category/java/errorprone.xml/DoNotCallGarbageCollectionExplicitly"/>
+  <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode"/>
+  <rule ref="category/java/errorprone.xml/MissingBreakInSwitch"/>
+
+  <!-- Performance with failure risk -->
+  <rule ref="category/java/performance.xml/InefficientEmptyStringCheck"/>
+  <rule ref="category/java/performance.xml/TooFewBranchesForSwitch"/>
+
+  <!-- Security-ish -->
+  <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP"/>
+  <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters"/>
+</ruleset>

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,61 @@
+rules:
+  # 1) SQL injection (nối chuỗi trong JPA/SQL)
+  - id: java-sql-concat
+    message: "Tránh nối chuỗi để tạo SQL/JPQL -> dùng bind parameters."
+    severity: ERROR
+    languages: [ java ]
+    patterns:
+      - pattern-either:
+          - pattern: |
+              String $q = "..." + $X + "...";
+              ... = $EM.createQuery($q, ...);
+          - pattern: |
+              $ST.executeQuery("..." + $X + "...")
+    metadata: { owasp: A03, cwe: "CWE-89" }
+
+  # 2) @CrossOrigin("*")
+  - id: spring-cors-all
+    message: "@CrossOrigin(\"*\") mở CORS toàn cục -> giới hạn origin cụ thể."
+    severity: ERROR
+    languages: [ java ]
+    pattern: |
+      @CrossOrigin("*") @AnnotatedClassOrMethod
+    metavariable-pattern:
+      metavariable: AnnotatedClassOrMethod
+      language: generic
+      pattern: ( class $C { ... } | @$M )
+
+  # 3) Tắt CSRF trên toàn bộ ứng dụng
+  - id: spring-disable-csrf
+    message: "Đang disable CSRF trên toàn app. Xem lại lý do và bù biện pháp khác."
+    severity: WARNING
+    languages: [ java ]
+    pattern: |
+      http.csrf().disable()
+
+  # 4) Bắt try/catch nuốt exception
+  - id: swallow-exception
+    message: "Đừng nuốt exception (catch rồi bỏ trống)."
+    severity: WARNING
+    languages: [ java ]
+    pattern: |
+      try { ... } catch ($E) { }
+
+  # 5) Rò rỉ IO stream (quên close)
+  - id: io-not-closed
+    message: "Nhớ đóng InputStream/Reader trong try-with-resources."
+    severity: WARNING
+    languages: [ java ]
+    pattern: |
+      InputStream $S = $X.openStream();
+      ...
+      // không có try-with-resources
+
+  # 6) Logging secrets/PII
+  - id: log-secrets
+    message: "Tránh log accessToken/secret/apiKey/password."
+    severity: WARNING
+    languages: [ java ]
+    pattern-either:
+      - pattern: Logger $L = ...; $L.info("...password..." , ... )
+      - pattern: Logger $L = ...; $L.warn("...accessToken..." , ... )

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -43,13 +43,26 @@ rules:
 
   # 5) Rò rỉ IO stream (quên close)
   - id: io-not-closed
-    message: "Nhớ đóng InputStream/Reader trong try-with-resources."
+    message: "Nhớ đóng InputStream/OutputStream/Reader/Writer trong try-with-resources."
     severity: WARNING
     languages: [ java ]
-    pattern: |
-      InputStream $S = $X.openStream();
-      ...
-      // không có try-with-resources
+    pattern-either:
+      - pattern: |
+          InputStream $S = $X.openStream();
+          ...
+          // không có try-with-resources
+      - pattern: |
+          OutputStream $S = $X.getOutputStream();
+          ...
+          // không có try-with-resources
+      - pattern: |
+          Reader $S = $X.getReader();
+          ...
+          // không có try-with-resources
+      - pattern: |
+          Writer $S = $X.getWriter();
+          ...
+          // không có try-with-resources
 
   # 6) Logging secrets/PII
   - id: log-secrets


### PR DESCRIPTION
This pull request adds strict security-focused configuration files for automated code review and static analysis, targeting only critical bug and security risks in Java code. The main changes include introducing configuration for CodeRabbit to enforce assertive, security-first reviews in Vietnamese, and adding custom rulesets for PMD and Semgrep to catch only high-risk issues.

**Security and Review Automation Configuration**

* Added `.coderabbit.yaml` to set CodeRabbit to review only for critical security and bug risks in `src/**`, with assertive tone and instructions in Vietnamese, and to enable only relevant security/static analysis tools (PMD, Semgrep, gitleaks, hadolint, yamllint), disabling unrelated linters.

**Static Analysis Rulesets**

* Added `.pmd-ruleset.xml` to configure PMD to flag only correctness, security, concurrency, resource-leak, and performance risks, using a minimal ruleset focused on high-impact Java issues.
* Added `.semgrep.yml` with custom Semgrep rules to detect critical Java security risks such as SQL injection, insecure CORS, disabled CSRF, swallowed exceptions, IO resource leaks, and logging of secrets/PII.

## Summary by Sourcery

Add strict, security-focused configurations for automated code review and static analysis, targeting only critical bug and security risks in Java code.

New Features:
- Add CodeRabbit config to enforce assertive, Vietnamese-language reviews on src/** for critical security and bug risks, enabling relevant security tools (gitleaks, hadolint, yamllint, PMD, Semgrep) and disabling unrelated linters
- Introduce a custom PMD ruleset to flag only high-impact correctness, security, concurrency, resource-leak, and performance issues in Java
- Add a Semgrep ruleset to detect critical Java security vulnerabilities such as SQL injection, insecure CORS, disabled CSRF, swallowed exceptions, IO resource leaks, and logging of secrets/PII