### PR TITLE
fix(course): fix course fetching does not have an index when using a list

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,7 @@ tone_instructions: "Vui lòng nói thẳng vấn đề và thẳng thắn"
 reviews:
   profile: assertive
   high_level_summary: false
-  collapse_walkthrough: true
+  collapse_walkthrough: false
   changed_files_summary: false
   sequence_diagrams: true         # tự vẽ sequence diagram trong Walkthrough
   suggested_labels: false

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,11 +120,26 @@ vinaacademy-backend/
 - **API Documentation**: Use Swagger annotations (`@Operation`, `@ApiResponses`, `@Schema`)
 
 ### MapStruct Configuration
-All mappers must use consistent configuration:
+
+All mappers must use the `INSTANCE` approach for consistent configuration:
+
 ```java
-@Mapper(componentModel = "spring",
-        unmappedTargetPolicy = ReportingPolicy.IGNORE,
-        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+@Mapper
+public interface UserMapper {
+
+    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+    User toUser(RegisterRequest registerRequest);
+
+    UserDto toDto(User user);
+
+    @Mapping(expression = "java(viewMappingDto.countCourseCreate)", target = "countCourseCreate")
+    @Mapping(expression = "java(viewMappingDto.countCourseEnroll)", target = "countCourseEnroll")
+    @Mapping(expression = "java(viewMappingDto.countCourseEnrollComplete)", target = "countCourseEnrollComplete")
+    @Mapping(target = "isActive", ignore = true)
+    @Mapping(target = "isCollaborator", ignore = true)
+    UserViewDto toViewDto(User user, @Context ViewMappingDto viewMappingDto);
+}
 ```
 
 ### Exception Handling
@@ -184,11 +199,24 @@ feature/{domain}/
 ```
 
 ### MapStruct Configuration
-All mappers use Spring component model with consistent configuration:
+All mappers must use the `INSTANCE` approach for consistent configuration:
 ```java
-@Mapper(componentModel = "spring",
-        unmappedTargetPolicy = ReportingPolicy.IGNORE,
-        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+@Mapper
+public interface UserMapper {
+
+    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+    User toUser(RegisterRequest registerRequest);
+
+    UserDto toDto(User user);
+
+    @Mapping(expression = "java(viewMappingDto.countCourseCreate)", target = "countCourseCreate")
+    @Mapping(expression = "java(viewMappingDto.countCourseEnroll)", target = "countCourseEnroll")
+    @Mapping(expression = "java(viewMappingDto.countCourseEnrollComplete)", target = "countCourseEnrollComplete")
+    @Mapping(target = "isActive", ignore = true)
+    @Mapping(target = "isCollaborator", ignore = true)
+    UserViewDto toViewDto(User user, @Context ViewMappingDto viewMappingDto);
+}
 ```
 
 ### Security & Authorization

--- a/src/main/java/com/vinaacademy/platform/feature/category/Category.java
+++ b/src/main/java/com/vinaacademy/platform/feature/category/Category.java
@@ -3,9 +3,8 @@ package com.vinaacademy.platform.feature.category;
 import com.vinaacademy.platform.feature.common.entity.BaseEntity;
 import com.vinaacademy.platform.feature.course.entity.Course;
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.util.List;
+import lombok.*;
 
 @Data
 @Getter
@@ -36,8 +35,10 @@ public class Category extends BaseEntity {
     private Category parent;
 
     @OneToMany(mappedBy = "parent")
+    @ToString.Exclude
     private List<Category> children;
 
     @OneToMany(mappedBy = "category")
+    @ToString.Exclude
     private List<Course> courses;
 }

--- a/src/main/java/com/vinaacademy/platform/feature/course/assembler/CourseAssembler.java
+++ b/src/main/java/com/vinaacademy/platform/feature/course/assembler/CourseAssembler.java
@@ -17,143 +17,164 @@ import com.vinaacademy.platform.feature.section.entity.Section;
 import com.vinaacademy.platform.feature.section.mapper.SectionMapper;
 import com.vinaacademy.platform.feature.user.UserMapper;
 import com.vinaacademy.platform.feature.user.entity.User;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Stream;
-
 /**
- * Assembler for course-related DTOs.
- * Centralizes the logic for building complex course DTOs with related entities.
+ * Assembler for course-related DTOs. Centralizes the logic for building complex course DTOs with
+ * related entities.
  */
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class CourseAssembler {
-    private final CourseInstructorRepository courseInstructorRepository;
+  private final CourseInstructorRepository courseInstructorRepository;
 
-    /**
-     * Assemble course details response with instructors, sections, lessons, and reviews
-     *
-     * @param course The course entity
-     * @return Complete course details response
-     */
-    public CourseDetailsResponse assembleCourseDetailsResponse(Course course) {
-        log.debug("Assembling course details response for course: {}", course.getId());
+  /**
+   * Assemble course details response with instructors, sections, lessons, and reviews
+   *
+   * @param course The course entity
+   * @return Complete course details response
+   */
+  public CourseDetailsResponse assembleCourseDetailsResponse(Course course) {
+    log.debug("Assembling course details response for course: {}", course.getId());
 
-        // Use CourseMapper to create the base course details
-        CourseDetailsResponse response = CourseMapper.INSTANCE.toCourseDetailsResponse(course);
+    // Use CourseMapper to create the base course details
+    CourseDetailsResponse response = CourseMapper.INSTANCE.toCourseDetailsResponse(course);
 
-        // Fetch and set instructors and owner instructor
-        buildInstructorsResponse(course, response);
+    // Fetch and set instructors and owner instructor
+    buildInstructorsResponse(course, response);
 
-        // Process sections with lessons
-        List<SectionDto> sectionDtos = processSectionsAndLessons(course.getSections());
-        response.setSections(sectionDtos);
+    // Process sections with lessons
+    List<SectionDto> sectionDtos = processSectionsAndLessons(course.getSections());
+    response.setSections(sectionDtos);
 
-        // Fetch course reviews
-        if (course.getCourseReviews() != null && !course.getCourseReviews().isEmpty()) {
-            List<CourseReviewDto> reviewDtos = course.getCourseReviews().stream()
-                    .map(CourseReviewMapper.INSTANCE::toDto)
-                    .toList();
-            response.setReviews(reviewDtos);
-        }
-
-        return response;
+    // Fetch course reviews
+    if (course.getCourseReviews() != null && !course.getCourseReviews().isEmpty()) {
+      List<CourseReviewDto> reviewDtos =
+          course.getCourseReviews().stream().map(CourseReviewMapper.INSTANCE::toDto).toList();
+      response.setReviews(reviewDtos);
     }
 
-    private void buildInstructorsResponse(Course course, CourseDetailsResponse response) {
-        boolean isFetchInstructors = Hibernate.isInitialized(course.getInstructors());
-        Stream<User> instructorUsers;
-        Optional<User> ownerUser;
-        if (isFetchInstructors) {
-            var cis = course.getInstructors();
-            instructorUsers = cis.stream().map(CourseInstructor::getInstructor);
-            ownerUser = cis.stream()
-                    .filter(CourseInstructor::getIsOwner)
-                    .map(CourseInstructor::getInstructor)
-                    .findFirst();
-        } else {
-            var projections = courseInstructorRepository.findByCourseId(course.getId());
-            instructorUsers = projections.stream().map(InstructorInfo::getInstructor);
-            ownerUser = projections.stream()
-                    .filter(InstructorInfo::getIsOwner)
-                    .map(InstructorInfo::getInstructor)
-                    .findFirst();
-        }
-        response.setInstructors(
-                instructorUsers.map(UserMapper.INSTANCE::toDto).toList()
-        );
-        ownerUser
-                .map(UserMapper.INSTANCE::toDto)
-                .ifPresent(response::setOwnerInstructor);
+    return response;
+  }
+
+  private void buildInstructorsResponse(Course course, CourseDetailsResponse response) {
+    boolean isFetchInstructors = Hibernate.isInitialized(course.getInstructors());
+
+    List<User> instructorUsers;
+    Optional<User> ownerUser;
+
+    if (isFetchInstructors) {
+      instructorUsers =
+          course.getInstructors().stream()
+              .filter(Objects::nonNull)
+              .map(CourseInstructor::getInstructor)
+              .filter(Objects::nonNull)
+              .toList();
+
+      ownerUser =
+          course.getInstructors().stream()
+              .filter(Objects::nonNull)
+              .filter(ci -> Boolean.TRUE.equals(ci.getIsOwner()))
+              .map(CourseInstructor::getInstructor)
+              .filter(Objects::nonNull)
+              .findFirst();
+
+    } else {
+      List<InstructorInfo> projections = courseInstructorRepository.findByCourseId(course.getId());
+
+      instructorUsers =
+          projections.stream()
+              .filter(Objects::nonNull)
+              .map(InstructorInfo::getInstructor)
+              .filter(Objects::nonNull)
+              .toList();
+
+      ownerUser =
+          projections.stream()
+              .filter(Objects::nonNull)
+              .filter(InstructorInfo::getIsOwner)
+              .map(InstructorInfo::getInstructor)
+              .filter(Objects::nonNull)
+              .findFirst();
     }
 
-    /**
-     * Process sections and their lessons, creating DTOs with sorted order
-     *
-     * @param sections List of section entities
-     * @return List of section DTOs with ordered lessons
-     */
-    public List<SectionDto> processSectionsAndLessons(List<Section> sections) {
-        if (sections == null || sections.isEmpty()) {
-            return List.of();
-        }
+    response.setInstructors(instructorUsers.stream().map(UserMapper.INSTANCE::toDto).toList());
+    ownerUser.map(UserMapper.INSTANCE::toDto).ifPresent(response::setOwnerInstructor);
+  }
 
-        return sections.stream()
-                .sorted(java.util.Comparator.comparing(Section::getOrderIndex))
-                .map(section -> {
-                    SectionDto sectionDto = SectionMapper.INSTANCE.toDto(section);
-                    // Fetch and map lessons for each section
-                    sectionDto.setLessons(section.getLessons().stream()
-                            .sorted(java.util.Comparator.comparing(Lesson::getOrderIndex))
-                            .map(LessonMapper.INSTANCE::lessonToLessonDto)
-                            .toList());
-                    return sectionDto;
-                })
-                .toList();
+  /**
+   * Process sections and their lessons, creating DTOs with sorted order
+   *
+   * @param sections List of section entities
+   * @return List of section DTOs with ordered lessons
+   */
+  public List<SectionDto> processSectionsAndLessons(List<Section> sections) {
+    if (sections == null || sections.isEmpty()) {
+      return List.of();
     }
 
-    /**
-     * Process sections and lessons with user progress information
-     *
-     * @param sections    List of section entities
-     * @param progressMap Map of lesson ID to user progress
-     * @return List of section DTOs with lessons including progress
-     */
-    public List<SectionDto> processSectionsAndLessonsWithProgress(List<Section> sections, Map<UUID, UserProgress> progressMap) {
-        if (sections == null || sections.isEmpty()) {
-            return List.of();
-        }
+    return sections.stream()
+        .sorted(java.util.Comparator.comparing(Section::getOrderIndex))
+        .map(
+            section -> {
+              SectionDto sectionDto = SectionMapper.INSTANCE.toDto(section);
+              // Fetch and map lessons for each section
+              sectionDto.setLessons(
+                  section.getLessons().stream()
+                      .sorted(java.util.Comparator.comparing(Lesson::getOrderIndex))
+                      .map(LessonMapper.INSTANCE::lessonToLessonDto)
+                      .toList());
+              return sectionDto;
+            })
+        .toList();
+  }
 
-        return sections.stream()
-                .sorted(java.util.Comparator.comparing(Section::getOrderIndex))
-                .map(section -> {
-                    SectionDto sectionDto = SectionMapper.INSTANCE.toDto(section);
-
-                    // Map lessons with progress
-                    List<LessonDto> lessonDtos = section.getLessons().stream()
-                            .sorted(java.util.Comparator.comparing(Lesson::getOrderIndex))
-                            .map(lesson -> {
-                                LessonDto lessonDto = LessonMapper.INSTANCE.lessonToLessonDto(lesson);
-                                // Add user progress if available
-                                UserProgress userProgress = progressMap.getOrDefault(
-                                        lesson.getId(),
-                                        new UserProgress());
-                                lessonDto.setCurrentUserProgress(userProgress);
-                                return lessonDto;
-                            })
-                            .toList();
-
-                    sectionDto.setLessons(lessonDtos);
-                    return sectionDto;
-                })
-                .toList();
+  /**
+   * Process sections and lessons with user progress information
+   *
+   * @param sections List of section entities
+   * @param progressMap Map of lesson ID to user progress
+   * @return List of section DTOs with lessons including progress
+   */
+  public List<SectionDto> processSectionsAndLessonsWithProgress(
+      List<Section> sections, Map<UUID, UserProgress> progressMap) {
+    if (sections == null || sections.isEmpty()) {
+      return List.of();
     }
+
+    return sections.stream()
+        .sorted(java.util.Comparator.comparing(Section::getOrderIndex))
+        .map(
+            section -> {
+              SectionDto sectionDto = SectionMapper.INSTANCE.toDto(section);
+
+              // Map lessons with progress
+              List<LessonDto> lessonDtos =
+                  section.getLessons().stream()
+                      .sorted(java.util.Comparator.comparing(Lesson::getOrderIndex))
+                      .map(
+                          lesson -> {
+                            LessonDto lessonDto = LessonMapper.INSTANCE.lessonToLessonDto(lesson);
+                            // Add user progress if available
+                            UserProgress userProgress =
+                                progressMap.getOrDefault(lesson.getId(), new UserProgress());
+                            lessonDto.setCurrentUserProgress(userProgress);
+                            return lessonDto;
+                          })
+                      .toList();
+
+              sectionDto.setLessons(lessonDtos);
+              return sectionDto;
+            })
+        .toList();
+  }
 }

--- a/src/main/java/com/vinaacademy/platform/feature/course/entity/Course.java
+++ b/src/main/java/com/vinaacademy/platform/feature/course/entity/Course.java
@@ -11,15 +11,14 @@ import com.vinaacademy.platform.feature.order_payment.entity.OrderItem;
 import com.vinaacademy.platform.feature.review.entity.CourseReview;
 import com.vinaacademy.platform.feature.section.entity.Section;
 import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import lombok.*;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 @Data
 @Getter
@@ -29,130 +28,136 @@ import java.util.UUID;
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @Entity
-@Table(name = "courses", indexes = {@Index(name = "inx_course_slug", columnList = "slug")})
+@Table(
+    name = "courses",
+    indexes = {@Index(name = "inx_course_slug", columnList = "slug")})
 public class Course extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
 
-    @Column(name = "image")
-    private String image;
+  @Column(name = "image")
+  private String image;
 
-    @Column(name = "name")
-    private String name;
+  @Column(name = "name")
+  private String name;
 
-    @Column(name = "description", columnDefinition = "TEXT")
-    private String description;
+  @Column(name = "description", columnDefinition = "TEXT")
+  private String description;
 
-    @Column(unique = true, name = "slug")
-    private String slug;
+  @Column(unique = true, name = "slug")
+  private String slug;
 
-    @Column(name = "price")
-    private BigDecimal price = BigDecimal.ZERO;
+  @Column(name = "price")
+  private BigDecimal price = BigDecimal.ZERO;
 
-    @Column(name = "level")
-    @Enumerated(EnumType.STRING)
-    private CourseLevel level = CourseLevel.BEGINNER;
+  @Column(name = "level")
+  @Enumerated(EnumType.STRING)
+  private CourseLevel level = CourseLevel.BEGINNER;
 
-    @Column(name = "status")
-    @Enumerated(EnumType.STRING)
-    private CourseStatus status = CourseStatus.DRAFT;
+  @Column(name = "status")
+  @Enumerated(EnumType.STRING)
+  private CourseStatus status = CourseStatus.DRAFT;
 
-    @Column(name = "language")
-    private String language = "Tiếng Việt";
+  @Column(name = "language")
+  private String language = "Tiếng Việt";
 
-    @ManyToOne
-    @JoinColumn(name = "category_id")
-    private Category category;
+  @ManyToOne
+  @JoinColumn(name = "category_id")
+  private Category category;
 
-    @Column(name = "rating")
-    private double rating = 0.0;
+  @Column(name = "rating")
+  private double rating = 0.0;
 
-    @Column(name = "total_rating")
-    private long totalRating = 0;
+  @Column(name = "total_rating")
+  private long totalRating = 0;
 
-    @Column(name = "total_student")
-    private long totalStudent = 0;
+  @Column(name = "total_student")
+  private long totalStudent = 0;
 
-    @Column(name = "total_section")
-    private long totalSection = 0;
+  @Column(name = "total_section")
+  private long totalSection = 0;
 
-    @Column(name = "total_lesson")
-    private long totalLesson = 0;
+  @Column(name = "total_lesson")
+  private long totalLesson = 0;
 
-    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderColumn(name = "order_index")
-    private List<Section> sections = new ArrayList<>();
+  @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderColumn(name = "order_index")
+  private List<Section> sections = new ArrayList<>();
 
-    public void addSection(Section section) {
-        sections.add(section);
-        section.setCourse(this);
-        totalSection = sections.size();
-        totalLesson = sections.stream().mapToLong(s -> s.getLessons().size()).sum();
+  public void addSection(Section section) {
+    sections.add(section);
+    section.setCourse(this);
+    totalSection = sections.size();
+    totalLesson = sections.stream().mapToLong(s -> s.getLessons().size()).sum();
+  }
+
+  public void removeSection(Section section) {
+    sections.remove(section);
+    section.setCourse(null);
+    totalSection = sections.size();
+    totalLesson = sections.stream().mapToLong(s -> s.getLessons().size()).sum();
+  }
+
+  public void addEnrollment(Enrollment enrollment) {
+    if (enrollments == null) {
+      enrollments = new ArrayList<>();
     }
+    enrollments.add(enrollment);
+    enrollment.setCourse(this);
+    totalStudent = enrollments.size();
+  }
 
-    public void removeSection(Section section) {
-        sections.remove(section);
-        section.setCourse(null);
-        totalSection = sections.size();
-        totalLesson = sections.stream().mapToLong(s -> s.getLessons().size()).sum();
+  public void removeEnrollment(Enrollment enrollment) {
+    if (enrollments != null) {
+      enrollments.remove(enrollment);
+      enrollment.setCourse(null);
+      totalStudent = enrollments.size();
     }
+  }
 
-    public void addEnrollment(Enrollment enrollment) {
-        if (enrollments == null) {
-            enrollments = new ArrayList<>();
-        }
-        enrollments.add(enrollment);
-        enrollment.setCourse(this);
-        totalStudent = enrollments.size();
+  public void addReview(CourseReview review) {
+    courseReviews.add(review);
+    review.setCourse(this);
+    recalculateRating();
+  }
+
+  public void removeReview(CourseReview review) {
+    courseReviews.remove(review);
+    review.setCourse(null);
+    recalculateRating();
+  }
+
+  private void recalculateRating() {
+    if (courseReviews.isEmpty()) {
+      rating = 0.0;
+      totalRating = 0;
+    } else {
+      totalRating = courseReviews.size();
+      rating = courseReviews.stream().mapToDouble(CourseReview::getRating).average().orElse(0.0);
     }
+  }
 
-    public void removeEnrollment(Enrollment enrollment) {
-        if (enrollments != null) {
-            enrollments.remove(enrollment);
-            enrollment.setCourse(null);
-            totalStudent = enrollments.size();
-        }
-    }
+  @OneToMany(mappedBy = "course", cascade = CascadeType.ALL)
+  private List<Enrollment> enrollments;
 
-    public void addReview(CourseReview review) {
-        courseReviews.add(review);
-        review.setCourse(this);
-        recalculateRating();
-    }
+  @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Fetch(FetchMode.SUBSELECT)
+  @BatchSize(size = 50)
+  @OrderColumn(name = "id")
+  private List<CourseInstructor> instructors = new ArrayList<>();
 
-    public void removeReview(CourseReview review) {
-        courseReviews.remove(review);
-        review.setCourse(null);
-        recalculateRating();
-    }
+  @OneToMany(mappedBy = "course", cascade = CascadeType.ALL)
+  @OrderColumn(name = "id")
+  private List<CartItem> cartItems;
 
-    private void recalculateRating() {
-        if (courseReviews.isEmpty()) {
-            rating = 0.0;
-            totalRating = 0;
-        } else {
-            totalRating = courseReviews.size();
-            rating = courseReviews.stream().mapToDouble(CourseReview::getRating).average().orElse(0.0);
-        }
-    }
+  @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Fetch(FetchMode.SUBSELECT)
+  @OrderColumn(name = "created_date")
+  @BatchSize(size = 50)
+  private List<CourseReview> courseReviews = new ArrayList<>();
 
-    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL)
-    private List<Enrollment> enrollments;
-
-    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Fetch(FetchMode.SUBSELECT)
-    @BatchSize(size = 50)
-    private List<CourseInstructor> instructors = new ArrayList<>();
-
-    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL)
-    private List<CartItem> cartItems;
-
-    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Fetch(FetchMode.SUBSELECT)
-    @BatchSize(size = 50)
-    private List<CourseReview> courseReviews = new ArrayList<>();
-
-    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL)
-    private List<OrderItem> orderItems;
+  @OneToMany(mappedBy = "course", cascade = CascadeType.ALL)
+  @OrderColumn(name = "id")
+  private List<OrderItem> orderItems;
 }

--- a/src/main/java/com/vinaacademy/platform/feature/course/entity/Course.java
+++ b/src/main/java/com/vinaacademy/platform/feature/course/entity/Course.java
@@ -85,6 +85,15 @@ public class Course extends BaseEntity {
   @OrderColumn(name = "order_index")
   private List<Section> sections = new ArrayList<>();
 
+  /**
+   * Adds a section to this course and updates the stored section and lesson aggregates.
+   *
+   * The section is appended to the course's sections list and its course reference is set
+   * to this course. After adding, totalSection is set to the current number of sections
+   * and totalLesson is recalculated as the sum of all lessons across every section.
+   *
+   * @param section the section to add to this course
+   */
   public void addSection(Section section) {
     sections.add(section);
     section.setCourse(this);
@@ -92,6 +101,18 @@ public class Course extends BaseEntity {
     totalLesson = sections.stream().mapToLong(s -> s.getLessons().size()).sum();
   }
 
+  /**
+   * Removes a section from this course and updates section/lesson counters.
+   *
+   * Removes the given Section from the course's sections list, clears the
+   * section's reference to this course, updates totalSection to the current
+   * number of sections, and recomputes totalLesson as the sum of lessons in
+   * all remaining sections.
+   *
+   * @param section the Section to remove; may be null or not present in the list,
+   *                in which case this method is a no-op for list membership but
+   *                will still attempt to clear the section's course reference
+   */
   public void removeSection(Section section) {
     sections.remove(section);
     section.setCourse(null);
@@ -99,6 +120,15 @@ public class Course extends BaseEntity {
     totalLesson = sections.stream().mapToLong(s -> s.getLessons().size()).sum();
   }
 
+  /**
+   * Adds an enrollment to this course.
+   *
+   * Initializes the enrollments list if necessary, adds the given enrollment,
+   * sets the enrollment's course reference to this course (maintaining the
+   * bidirectional association), and updates the course's totalStudent counter.
+   *
+   * @param enrollment the enrollment to add; must not be null
+   */
   public void addEnrollment(Enrollment enrollment) {
     if (enrollments == null) {
       enrollments = new ArrayList<>();
@@ -108,6 +138,14 @@ public class Course extends BaseEntity {
     totalStudent = enrollments.size();
   }
 
+  /**
+   * Removes an enrollment from this course, clears the enrollment's course reference,
+   * and updates the course's totalStudent counter.
+   *
+   * If the course has no enrollments list (null), the method is a no-op.
+   *
+   * @param enrollment the Enrollment to remove; may be null (no-op) or an instance associated with this course
+   */
   public void removeEnrollment(Enrollment enrollment) {
     if (enrollments != null) {
       enrollments.remove(enrollment);
@@ -116,18 +154,38 @@ public class Course extends BaseEntity {
     }
   }
 
+  /**
+   * Adds a review to this course and updates the course's aggregate rating.
+   *
+   * The given review is appended to the course's review list, its `course` reference
+   * is set to this course, and the course rating/totalRating are recomputed.
+   *
+   * @param review the CourseReview to add; its `course` field will be set to this instance
+   */
   public void addReview(CourseReview review) {
     courseReviews.add(review);
     review.setCourse(this);
     recalculateRating();
   }
 
+  /**
+   * Removes the given review from this course, clears the review's course reference, and recalculates the course's rating and rating count.
+   *
+   * @param review the non-null CourseReview to remove; its reference to this course will be cleared and the course rating will be updated
+   */
   public void removeReview(CourseReview review) {
     courseReviews.remove(review);
     review.setCourse(null);
     recalculateRating();
   }
 
+  /**
+   * Recomputes this course's aggregate rating and rating count from its reviews.
+   *
+   * If there are no reviews, sets both {@code rating} and {@code totalRating} to zero.
+   * Otherwise sets {@code totalRating} to the number of reviews and {@code rating}
+   * to the arithmetic mean of all review ratings.
+   */
   private void recalculateRating() {
     if (courseReviews.isEmpty()) {
       rating = 0.0;

--- a/src/main/java/com/vinaacademy/platform/feature/lesson/entity/Lesson.java
+++ b/src/main/java/com/vinaacademy/platform/feature/lesson/entity/Lesson.java
@@ -6,11 +6,10 @@ import com.vinaacademy.platform.feature.section.entity.Section;
 import com.vinaacademy.platform.feature.storage.entity.MediaFile;
 import com.vinaacademy.platform.feature.user.entity.User;
 import jakarta.persistence.*;
-import lombok.*;
-import lombok.experimental.SuperBuilder;
-
 import java.util.List;
 import java.util.UUID;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Data
 @Getter
@@ -31,6 +30,7 @@ public abstract class Lesson extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "section_id", nullable = false)
+    @ToString.Exclude
     protected Section section;
 
     @Column(name = "title")
@@ -51,6 +51,7 @@ public abstract class Lesson extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "author_id", nullable = false)
+    @ToString.Exclude
     protected User author;
 
     @Version
@@ -58,6 +59,7 @@ public abstract class Lesson extends BaseEntity {
     private Long version;
 
     @OneToMany(mappedBy = "lesson", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+    @ToString.Exclude
     protected List<UserProgress> progressList;
 
     @ManyToMany
@@ -66,6 +68,7 @@ public abstract class Lesson extends BaseEntity {
             joinColumns = @JoinColumn(name = "lesson_id"),
             inverseJoinColumns = @JoinColumn(name = "media_file_id")
     )
+    @ToString.Exclude
     protected List<MediaFile> mediaFiles;
 
 }

--- a/src/main/java/com/vinaacademy/platform/feature/user/UserMapper.java
+++ b/src/main/java/com/vinaacademy/platform/feature/user/UserMapper.java
@@ -5,13 +5,12 @@ import com.vinaacademy.platform.feature.user.dto.UserDto;
 import com.vinaacademy.platform.feature.user.dto.UserViewDto;
 import com.vinaacademy.platform.feature.user.dto.ViewMappingDto;
 import com.vinaacademy.platform.feature.user.entity.User;
-
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(componentModel = "spring")
+@Mapper
 public interface UserMapper {
     UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 


### PR DESCRIPTION
This pull request introduces several improvements to entity relationships and object representations in the codebase. The main changes focus on preventing potential issues with circular references in `toString()` methods by excluding certain fields, and on improving the ordering of related entity lists using JPA annotations. Additionally, there are minor import ordering cleanups for consistency.

**Entity relationship and object representation improvements:**

* Added `@ToString.Exclude` to relationship fields in `Category`, `Lesson`, and `Course`-related entities to prevent circular references and stack overflow errors when using Lombok's `toString()` methods. [[1]](diffhunk://#diff-10a676ef695aed943a20328580b0e9d5927f8a09f6466a32bdf078e593553bceR38-R42) [[2]](diffhunk://#diff-d72dbacded65682e1a387b176d25f536caab90edfe67d66e55b256c22bfbb43fR33) [[3]](diffhunk://#diff-d72dbacded65682e1a387b176d25f536caab90edfe67d66e55b256c22bfbb43fR54-R62) [[4]](diffhunk://#diff-d72dbacded65682e1a387b176d25f536caab90edfe67d66e55b256c22bfbb43fR71)

**Entity list ordering enhancements:**

* Added `@OrderColumn` annotations to several list fields in `Course` (`instructors`, `cartItems`, `courseReviews`, `orderItems`) to ensure lists are persisted and retrieved in a consistent order.

**Code style and import cleanup:**

* Reordered and cleaned up import statements in `Category.java`, `Course.java`, and `Lesson.java` for better readability and consistency. [[1]](diffhunk://#diff-10a676ef695aed943a20328580b0e9d5927f8a09f6466a32bdf078e593553bceL6-R7) [[2]](diffhunk://#diff-34389ffc50a959a5a05766454c4d5511fa8f59de9db6cf0d3c2ad34743fcbc64L14-R21) [[3]](diffhunk://#diff-d72dbacded65682e1a387b176d25f536caab90edfe67d66e55b256c22bfbb43fL9-R12)

**JPA table annotation formatting:**

* Reformatted the `@Table` annotation in `Course.java` for improved readability.